### PR TITLE
Fix header and source file incongruity

### DIFF
--- a/elf/elf++.hh
+++ b/elf/elf++.hh
@@ -142,7 +142,7 @@ public:
  * will close fd when done, so the caller should dup the file
  * descriptor if it intends to continue using it.
  */
-std::shared_ptr<loader> create_mmap_loader(int fd);
+std::shared_ptr<loader> create_mmap_loader(const char* path);
 
 /**
  * An exception indicating that a section is not of the requested type.

--- a/examples/dump-sections.cc
+++ b/examples/dump-sections.cc
@@ -13,13 +13,7 @@ int main(int argc, char **argv)
                 return 2;
         }
 
-        int fd = open(argv[1], O_RDONLY);
-        if (fd < 0) {
-                fprintf(stderr, "%s: %s\n", argv[1], strerror(errno));
-                return 1;
-        }
-
-        elf::elf f(elf::create_mmap_loader(fd));
+        elf::elf f(elf::create_mmap_loader(argv[1]));
         int i = 0;
         printf("  [Nr] %-16s %-16s %-16s %s\n",
                "Name", "Type", "Address", "Offset");


### PR DESCRIPTION
`create_mmap_loader()` has been changed to take a path (string) argument instead of a file descriptor. The header must be updated to reflect this change in the implementation.